### PR TITLE
削除済みアイテムを非表示

### DIFF
--- a/port-sqlite3-repository.go
+++ b/port-sqlite3-repository.go
@@ -22,7 +22,7 @@ func (this *SqliteItemRepository) Items() (items []*Item, err error) {
 	}
 	defer db.Close()
 
-	rows, err := db.Query("select Z_PK, ZTITLE, ZBODY, ZRAW_BODY from ZITEM order by ZUPDATED_AT desc")
+	rows, err := db.Query("select Z_PK, ZTITLE, ZBODY, ZRAW_BODY from ZITEM where ZIN_TRASH is null order by ZUPDATED_AT desc")
 
 	if err != nil {
 		return


### PR DESCRIPTION
最近kobit-cliを使い始めました．
そこで「`kobito ls`で削除したアイテムも表示される」のが気になったので，修正してみました．
どうやら，`ZIN_TRASH`が`1`の場合は削除，`null`の場合は存在のようです．
よろしくお願いします．
